### PR TITLE
Make blockquote font color a bit darker

### DIFF
--- a/styles/custom.scss
+++ b/styles/custom.scss
@@ -350,18 +350,22 @@ h4:hover .header-anchor-select {
     }
 }
 
-blockquote.tip {
+blockquote {
+  color: #696969;
+
+  &.tip {
     font-size: medium;
     background-color: #F5FFFB;
     padding: 1em;
     margin-bottom: 1em;
-}
+  }
 
-blockquote.warning {
+  &.warning {
     font-size: medium;
     background-color: #FFFFFA;
     padding: 1em;
     margin-bottom: 1em;
+  }
 }
 
 .github-fork-ribbon-wrapper.ribbon {


### PR DESCRIPTION
The background of the `blockquote` is enough to make a difference between normal text and the quote.

I bumped the color a bit on the font because it was really hard to read.