### PR TITLE
Add a custom style for warning quotes

### DIFF
--- a/styles/custom.scss
+++ b/styles/custom.scss
@@ -362,7 +362,7 @@ blockquote {
 
   &.warning {
     font-size: medium;
-    background-color: #FFFFFA;
+    background-color: rgba(red, 0.25);
     padding: 1em;
     margin-bottom: 1em;
   }


### PR DESCRIPTION
This is highly subjective, but the actual `warning` blockquotes are white. That is not enough warning for me.

I add an screenshot here so you can see how it looks like. Feel free to change it, that is not important.

![screenshot](http://puu.sh/jiSKs/d4ca019574.png)