### PR TITLE
Fixed link to "this is the source of"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SurviveJS - Site
 
-This is the source of [survivejs.com](survivejs.com).
+This is the source of [http://survivejs.com/](survivejs.com).
 
 ## Development
 


### PR DESCRIPTION
replaced "survivejs.com" with "http://survivejs.com/" since the original link tried to find a file on github in this repository.