### PR TITLE
Update fork ribbon URL for blog pages

### DIFF
--- a/layouts/Body.jsx
+++ b/layouts/Body.jsx
@@ -55,6 +55,9 @@ export default React.createClass({
     );
   },
   renderFeedback(title, sectionName) {
+    if (sectionName === 'blog') {
+      sectionName = 'site';
+    }
     return <Fork className="right ribbon"
       project={`survivejs/${sectionName}/issues/new?title=${title} - `}
       text="Submit feedback"


### PR DESCRIPTION
The URL would point at https://github.com/survivejs/blog where https://github.com/survivejs/site seems to be the intention